### PR TITLE
Restructuring the IAB Workshop definition as .md file.

### DIFF
--- a/IAB Workshop.md
+++ b/IAB Workshop.md
@@ -1,0 +1,33 @@
+# Introduction
+The IAB organized a workshop in 2002 to establish a
+dialog between network operators and protocol developers, and to guide the IETF focus on work regarding network management. That workshop identified 14 requirements that the operators wanted to see in the next generation of management, and was documented in the "IAB Network Management Workshop" (RFC 3535). The RFC was instrumental in the development of NETCONF, YANG, and RESTCONF.
+
+This IAB workshop should look at whether those requirements been met, and more importantly gather input on what are some of the new requirements the operators are facing.
+
+# Current Implementation
+With what had been specified in RFC 3535, what does the implementation look like? If there are hurdles towards implementation, what are they? IETF has defined XXX number of YANG models. (Benoit can probably identify what that number is). How many have been implemeted? How does that implementation look like? If not many have been implemented, why not? What are operators using, if it is not the IETF models? OpenConfig models or vendor specific models?
+
+
+# New Requirements
+
+20 years later, new requirements on network management operations are emerging from the operators. This workshop intends to identify and discuss the new requirements.
+
+For example, there is a strong desire to automate network management. What are we missing that will enable that automation?
+
+Artifical Intelligence (AI) has placed requirements on network management. What are some of those requirements?
+
+# Tooling and Libraries
+
+Part of the problem with adoption could be related towards availability of tools and libraries. Are we missing tools that will enable adoption and automation? Are we missing sample implementations or libraries that customers can use “out-of-the” box? Should such implementations appear
+in public sources like Sonic or FRR? 
+
+# A minimum set
+
+Would it help to identify a set of models that belong to a YANG library that are known to work together?
+What will constitute a minimal set of models that should be known to work together? 
+
+# Outreach
+In 2002, there were enough operators attending IETF meetings. Those numbers have dwindled over time, with some of the operators attending conferences that are more operator focused. These include RIPE, NANOG, AutoConn etc.
+
+As such the IAB may have to do an outreach effort to get the input they are looking for. A tentative plan is to target these conferences in the October/November 2024 timeframe, followed by a virtual workshop in December to discuss the findings. 
+


### PR DESCRIPTION
I took the IAB workshop text file, and reformatted it as .md file, adding in some of the discussion points that were raised earlier today (May 22, 2024).

Feel free to take a whack at it.